### PR TITLE
Replace additive persistence with credit card validation

### DIFF
--- a/.github/classroom/autograding.json
+++ b/.github/classroom/autograding.json
@@ -1,126 +1,6 @@
 {
   "tests": [
-    { 
-      "name": "sumList 1",
-      "run": "stack test --allow-different-user --ta '--pattern \"sumList 1\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "sumList 2",
-      "run": "stack test --allow-different-user --ta '--pattern \"sumList 2\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "sumList 3",
-      "run": "stack test --allow-different-user --ta '--pattern \"sumList 3\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "sumList 4",
-      "run": "stack test --allow-different-user --ta '--pattern \"sumList 4\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-    { 
-      "name": "digitsOfInt 1",
-      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInt 1\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "digitsOfInt 2",
-      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInt 2\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "digits 1",
-      "run": "stack test --allow-different-user --ta '--pattern \"digits 1\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "digits 2",
-      "run": "stack test --allow-different-user --ta '--pattern \"digits 2\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 2.5
-    },
-     { 
-      "name": "additivePersistence 1",
-      "run": "stack test --allow-different-user --ta '--pattern \"additivePersistence 1\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 5
-    },
-     { 
-      "name": "additivePersistence 2",
-      "run": "stack test --allow-different-user --ta '--pattern \"additivePersistence 2\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 5
-    },
-     { 
-      "name": "digitalRoot 1",
-      "run": "stack test --allow-different-user --ta '--pattern \"digitalRoot 1\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 5
-    },
-     { 
-      "name": "digitalRoot 2",
-      "run": "stack test --allow-different-user --ta '--pattern \"digitalRoot 2\"'",
-      "setup": "",
-      "input": "",
-      "output": "",
-      "comparison": "included",
-      "timeout": 10,
-      "points": 5
-    },
-     { 
+     {
       "name": "reverse 1",
       "run": "stack test --allow-different-user --ta '--pattern \"reverse 1\"'",
       "setup": "",
@@ -130,7 +10,7 @@
       "timeout": 10,
       "points": 7.5
     },
-     { 
+     {
       "name": "reverse 2",
       "run": "stack test --allow-different-user --ta '--pattern \"reverse 2\"'",
       "setup": "",
@@ -140,7 +20,18 @@
       "timeout": 10,
       "points": 7.5
     },
-     { 
+     {
+      "name": "reverse 3",
+      "run": "stack test --allow-different-user --ta '--pattern \"reverse 3\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+
+     {
       "name": "palindrome 1",
       "run": "stack test --allow-different-user --ta '--pattern \"palindrome 1\"'",
       "setup": "",
@@ -150,7 +41,7 @@
       "timeout": 10,
       "points": 5
     },
-     { 
+     {
       "name": "palindrome 2",
       "run": "stack test --allow-different-user --ta '--pattern \"palindrome 2\"'",
       "setup": "",
@@ -159,6 +50,161 @@
       "comparison": "included",
       "timeout": 10,
       "points": 5
+    },
+     {
+      "name": "palindrome 3",
+      "run": "stack test --allow-different-user --ta '--pattern \"palindrome 3\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+
+    {
+      "name": "digitsOfInt 1",
+      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInt 1\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+     {
+      "name": "digitsOfInt 2",
+      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInt 2\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+     {
+      "name": "digitsOfInt 3",
+      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInt 3\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2
+    },
+
+    {
+      "name": "digitsOfInts 1",
+      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInts 1\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2.5
+    },
+     {
+      "name": "digitsOfInts 2",
+      "run": "stack test --allow-different-user --ta '--pattern \"digitsOfInts 2\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2.5
+    },
+
+    {
+      "name": "doubleEveryOther 1",
+      "run": "stack test --allow-different-user --ta '--pattern \"doubleEveryOther 1\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+     {
+      "name": "doubleEveryOther 2",
+      "run": "stack test --allow-different-user --ta '--pattern \"doubleEveryOther 2\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+     {
+      "name": "doubleEveryOther 3",
+      "run": "stack test --allow-different-user --ta '--pattern \"doubleEveryOther 3\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 5
+    },
+
+     {
+      "name": "sumList 1",
+      "run": "stack test --allow-different-user --ta '--pattern \"sumList 1\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2.5
+    },
+     {
+      "name": "sumList 2",
+      "run": "stack test --allow-different-user --ta '--pattern \"sumList 2\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2.5
+    },
+     {
+      "name": "sumList 3",
+      "run": "stack test --allow-different-user --ta '--pattern \"sumList 3\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2.5
+    },
+     {
+      "name": "sumList 4",
+      "run": "stack test --allow-different-user --ta '--pattern \"sumList 4\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 2.5
+    },
+
+     {
+      "name": "validateCardNumber 1",
+      "run": "stack test --allow-different-user --ta '--pattern \"validateCardNumber 1\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 10
+    },
+     {
+      "name": "validateCardNumber 2",
+      "run": "stack test --allow-different-user --ta '--pattern \"validateCardNumber 2\"'",
+      "setup": "",
+      "input": "",
+      "output": "",
+      "comparison": "included",
+      "timeout": 10,
+      "points": 10
     }
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .stack-work
 *.log
 *.lock
+config.json

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,7 @@
+{
+    "course": "CSE-114A-S24",
+    "assignment": "01-haskell",
+    "server": "http://lighthouse.soe.ucsc.edu",
+    "user": "sslug@ucsc.edu",
+    "pass": "1234567890"
+}

--- a/src/Hw1.hs
+++ b/src/Hw1.hs
@@ -17,19 +17,36 @@ module Hw1 where
 import Prelude  hiding (replicate, sum, reverse)
 
 
--- | Sum the elements of a list
+-- | Reverse the order of elements in a list; in other words,
+--   `listReverse [x1, x2, ..., xn]` returns `[xn, ..., x2, x1]`.
 --
--- >>> sumList [1, 2, 3, 4]
--- 10
+-- >>> listReverse [1,2,3,4]
+-- [4,3,2,1]
 --
--- >>> sumList [1, -2, 3, 5]
--- 7
+-- >>> listReverse ["i", "want", "to", "ride", "my", "bicycle"]
+-- ["bicycle", "my", "ride", "to", "want", "i"]
 --
--- >>> sumList [1, 3, 5, 7, 9, 11]
--- 36
+-- >>> listReverse []
+-- []
 
-sumList :: [Int] -> Int
-sumList xs = error "TBD:sumList"
+listReverse :: [a] -> [a]
+listReverse xs = error "TBD:listReverse"
+
+
+-- | Determine whether a string is a palindrome (i.e. spelled the same
+--   both backwards and forwards).
+--
+-- >>> palindrome "malayalam"
+-- True
+--
+-- >>> palindrome "palindrome"
+-- False
+--
+-- >>> palindrome ""
+-- True
+
+palindrome :: String -> Bool
+palindrome w = error "TBD:palindrome"
 
 
 -- | `digitsOfInt n` should return `[]` if `n` is not positive,
@@ -41,83 +58,65 @@ sumList xs = error "TBD:sumList"
 --
 -- >>> digitsOfInt 352663
 -- [3, 5, 2, 6, 6, 3]
+--
+-- >>> digitsOfInt -42
+-- []
 
-digitsOfInt :: Int -> [Int]
+digitsOfInt :: Integer -> [Integer]
 digitsOfInt n = error "TBD:digitsOfInt"
 
 
--- | `digits n` returns the list of digits of `n`
+-- | `digitsOfInts xs` should return a list containing all of the digits
+--   for every number in `xs`, in the same order they appeared in `xs`.
 --
--- >>> digits 31243
--- [3,1,2,4,3]
+-- >>> digitsOfInts [3124, 52, -42, 8]
+-- [3, 1, 2, 4, 5, 2, 8]
 --
--- digits (-23422)
--- [2, 3, 4, 2, 2]
-
-digits :: Int -> [Int]
-digits n = digitsOfInt (abs n)
-
-
--- | From http://mathworld.wolfram.com/AdditivePersistence.html
---   Consider the process of taking a number, adding its digits,
---   then adding the digits of the number derived from it, etc.,
---   until the remaining number has only one digit.
---   The number of additions required to obtain a single digit
---   from a number n is called the additive persistence of n,
---   and the digit obtained is called the digital root of n.
---   For example, the sequence obtained from the starting number
---   9876 is 9876 -> 30 -> 3, so 9876 has
---   an additive persistence of 2 and
---   a digital root of 3.
---
--- NOTE: assume additivePersistence & digitalRoot are only called with positive numbers
-
--- >>> additivePersistence 9876
--- 2
-
--- >>> additivePersistence 99999
--- 2
-
-additivePersistence :: Int -> Int
-additivePersistence n = error "TBD"
-
--- | digitalRoot n is the digit obtained at the end of the sequence
---   computing the additivePersistence
-
--- >>> digitalRoot 9876
--- 3
-
--- >>> digitalRoot 99999
--- 9
-
-digitalRoot :: Int -> Int
-digitalRoot n = error "TBD"
-
-
--- | listReverse [x1,x2,...,xn] returns [xn,...,x2,x1]
---
--- >>> listReverse []
+-- >>> digitsOfInts []
 -- []
---
--- >>> listReverse [1,2,3,4]
--- [4,3,2,1]
---
--- >>> listReverse ["i", "want", "to", "ride", "my", "bicycle"]
--- ["bicycle", "my", "ride", "to", "want", "i"]
 
-listReverse :: [a] -> [a]
-listReverse xs = error "TBD"
+digitsOfInts :: [Integer] -> [Integer]
+digitsOfInts xs = error "TBD:digitsOfInts"
 
--- | In Haskell, a `String` is a simply a list of `Char`, that is:
+
+-- | Doubles every other integer in a list,
+--   starting with the second element.
 --
--- >>> ['h', 'a', 's', 'k', 'e', 'l', 'l']
--- "haskell"
+-- >>> doubleEveryOther [8,7,6,5]
+-- [8,14,6,10]
 --
--- >>> palindrome "malayalam"
+-- >>> doubleEveryOther [1,2,3]
+-- [1,4,3]
+--
+-- >>> doubleEveryOther []
+-- []
+
+doubleEveryOther :: [Integer] -> [Integer]
+doubleEveryOther xs = error "TBD:doubleEveryOther"
+
+
+-- | Sum the elements of a list
+--
+-- >>> sumList [1, 2, 3, 4]
+-- 10
+--
+-- >>> sumList [1, -2, 3, 5]
+-- 7
+--
+-- >>> sumList [1, 3, 5, 7, 9, 11]
+-- 36
+
+sumList :: [Integer] -> Integer
+sumList xs = error "TBD:sumList"
+
+
+-- | Validate a credit card number
+--
+-- >>> validateCardNumber 4012888888881881
 -- True
 --
--- >>> palindrome "myxomatosis"
+-- >>> validateCardNumber 4012888888881882
 -- False
 
-palindrome :: String -> Bool
-palindrome w = error "TBD"
+validateCardNumber :: Integer -> Bool
+validateCardNumber = error "TBD:validateCardNumber"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-21.14
+resolver: lts-21.13
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: 
+extra-deps:
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -1,6 +1,6 @@
 import Test.Tasty
 import Common
-import Hw1 
+import Hw1
 
 main :: IO ()
 main = runTests [unit1]
@@ -8,11 +8,86 @@ main = runTests [unit1]
 unit1 :: Score -> TestTree
 unit1 sc = testGroup "Unit 1"
   [ mkTest
+      listReverse
+      [1, 2, 3, 4]
+      [4, 3, 2, 1]
+      "reverse 1"
+  , mkTest
+      listReverse
+      ["a", "b", "c", "d"]
+      ["d", "c", "b", "a"]
+      "reverse 2"
+  , mkTest
+      listReverse
+      ([] :: [Integer])
+      []
+      "reverse 3"
+
+  , mkTest
+      palindrome
+      "malayalam"
+      True
+      "palindrome 1"
+  , mkTest
+      palindrome
+      "palindrome"
+      False
+      "palindrome 2"
+  , mkTest
+      palindrome
+      ""
+      True
+      "palindrome 3"
+
+  , mkTest
+      digitsOfInt
+      3124
+      [3, 1, 2, 4]
+      "digitsOfInt 1"
+  , mkTest
+      digitsOfInt
+      352663
+      [3, 5, 2, 6, 6, 3]
+      "digitsOfInt 2"
+  , mkTest
+      digitsOfInt
+      (-42)
+      []
+      "digitsOfInt 3"
+
+  , mkTest
+      digitsOfInts
+      [3124, 52, -42, 8]
+      [3, 1, 2, 4, 5, 2, 8]
+      "digitsOfInts 1"
+  , mkTest
+      digitsOfInts
+      []
+      []
+      "digitsOfInts 2"
+
+  , mkTest
+      doubleEveryOther
+      [8,7,6,5]
+      [8,14,6,10]
+      "doubleEveryOther 1"
+  , mkTest
+      doubleEveryOther
+      [1,2,3]
+      [1,4,3]
+      "doubleEveryOther 2"
+  , mkTest
+      doubleEveryOther
+      []
+      []
+      "doubleEveryOther 3"
+
+  , mkTest
       sumList
       []
       0
       "sumList 1"
-  ,mkTest
+  , mkTest
       sumList
       [1, 2, 3, 4]
       10
@@ -27,66 +102,17 @@ unit1 sc = testGroup "Unit 1"
       [1, 3, 5, 7, 9, 11]
       36
       "sumList 4"
+
   , mkTest
-      digitsOfInt
-      3124
-      [3, 1, 2, 4]
-      "digitsOfInt 1"
-  , mkTest
-      digitsOfInt
-      352663
-      [3, 5, 2, 6, 6, 3]
-      "digitsOfInt 2"
-  , mkTest
-      digits
-      31243
-      [3, 1, 2, 4, 3]
-      "digits 1"
-  , mkTest
-      digits
-      (-23422)
-      [2, 3, 4, 2, 2]
-      "digits 2"
-  , mkTest
-      additivePersistence
-      9876
-      2
-      "additivePersistence 1"
-  , mkTest
-      additivePersistence
-      1
-      0
-      "additivePersistence 2"
-  , mkTest
-      digitalRoot
-      9876
-      3
-      "digitalRoot 1"
-  , mkTest
-      digitalRoot
-      1
-      1
-      "digitalRoot 2"
-  , mkTest
-      listReverse
-      [1, 2, 3, 4]
-      [4, 3, 2, 1]
-      "reverse 1"
-  , mkTest
-      listReverse
-      ["a", "b", "c", "d"]
-      ["d", "c", "b", "a"]
-      "reverse 2"
-  , mkTest
-      palindrome
-      "malayalam"
+      validateCardNumber
+      4012888888881881
       True
-      "palindrome 1"
+      "validateCardNumber 1"
   , mkTest
-      palindrome
-      "myxomatosis"
+      validateCardNumber
+      4012888888881882
       False
-      "palindrome 2"
+      "validateCardNumber 2"
   ]
   where
     mkTest :: (Show b, Eq b) => (a -> b) -> a -> b -> String -> TestTree


### PR DESCRIPTION
Per discussion [on Zulip](https://ucsc-cse114a.zulipchat.com/#narrow/stream/431751-course-staff/topic/HW1/near/433073163), I've replaced the additive persistence subproblem with a credit card validation problem. Since this notionally makes use of `reverseList`, I've reordered definitions so that the palindrome subproblem comes first.

Artifacts left to update at this point:
* The `README`
* The reference solution to HW1 in the `grading` repository

We also need to set up the EriqGrader infrastructure for these tests; but because HW1 still needs to be integrated with EriqGrader, that change is separable.

At the moment, we do not plan to update the existing Dockerfile and build grading image used by Gradescope, because we're using the EricGrader backend instead.