### PR TITLE
Make point totals for local grading code match autograder behavior

### DIFF
--- a/tests/Common.hs
+++ b/tests/Common.hs
@@ -10,7 +10,7 @@ import Test.Tasty.Runners
 import System.Exit
 import Control.Exception
 
-type Score = IORef (Int, Int)
+type Score = IORef (Double, Double)
 
 runTests :: [Score -> TestTree] -> IO ()
 runTests groups = do
@@ -31,22 +31,22 @@ tests x gs = testGroup "Tests" [ g x | g <- gs ]
 -- | Construct a single test case
 --------------------------------------------------------------------------------
 mkTest' :: (Show b, Eq b) => Score -> (a -> b) -> a -> b -> String -> TestTree
-mkTest' sc f x r name = scoreTest' sc (f, x, r, 1, name)
+mkTest' sc f x r name = scoreTest' sc f x r 1 name
 
 --------------------------------------------------------------------------------
-scoreTest' :: (Show b, Eq b) => Score -> (a -> b, a, b, Int, String) -> TestTree
+scoreTest' :: (Show b, Eq b) => Score -> (a -> b) -> a -> b -> Double -> String -> TestTree
 --------------------------------------------------------------------------------
-scoreTest' sc (f, x, expR, points, name) =
+scoreTest' sc f x expR points name =
   testCase name $ do
     updateTotal sc points
     if f x == expR
       then updateCurrent sc points
       else assertFailure "Wrong Result"
 
-updateTotal :: Score -> Int -> IO ()
+updateTotal :: Score -> Double -> IO ()
 updateTotal sc n = modifyIORef sc (\(x, y) -> (x, y + n))
 
-updateCurrent :: Score -> Int -> IO ()
+updateCurrent :: Score -> Double -> IO ()
 updateCurrent sc n = modifyIORef sc (\(x, y) -> (x + n, y))
 
 initScore :: IO Score

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -11,109 +11,129 @@ unit1 sc = testGroup "Unit 1"
       listReverse
       [1, 2, 3, 4]
       [4, 3, 2, 1]
+      7.5
       "reverse 1"
   , mkTest
       listReverse
       ["a", "b", "c", "d"]
       ["d", "c", "b", "a"]
+      7.5
       "reverse 2"
   , mkTest
       listReverse
       ([] :: [Integer])
       []
+      5
       "reverse 3"
 
   , mkTest
       palindrome
       "malayalam"
       True
+      5
       "palindrome 1"
   , mkTest
       palindrome
       "palindrome"
       False
+      5
       "palindrome 2"
   , mkTest
       palindrome
       ""
       True
+      5
       "palindrome 3"
 
   , mkTest
       digitsOfInt
       3124
       [3, 1, 2, 4]
+      5
       "digitsOfInt 1"
   , mkTest
       digitsOfInt
       352663
       [3, 5, 2, 6, 6, 3]
+      5
       "digitsOfInt 2"
   , mkTest
       digitsOfInt
       (-42)
       []
+      2
       "digitsOfInt 3"
 
   , mkTest
       digitsOfInts
       [3124, 52, -42, 8]
       [3, 1, 2, 4, 5, 2, 8]
+      2.5
       "digitsOfInts 1"
   , mkTest
       digitsOfInts
       []
       []
+      2.5
       "digitsOfInts 2"
 
   , mkTest
       doubleEveryOther
       [8,7,6,5]
       [8,14,6,10]
+      5
       "doubleEveryOther 1"
   , mkTest
       doubleEveryOther
       [1,2,3]
       [1,4,3]
+      5
       "doubleEveryOther 2"
   , mkTest
       doubleEveryOther
       []
       []
+      5
       "doubleEveryOther 3"
 
   , mkTest
       sumList
       []
       0
+      2.5
       "sumList 1"
   , mkTest
       sumList
       [1, 2, 3, 4]
       10
+      2.5
       "sumList 2"
   , mkTest
       sumList
       [1, -2, 3, 5]
       7
+      2.5
       "sumList 3"
   , mkTest
       sumList
       [1, 3, 5, 7, 9, 11]
       36
+      2.5
       "sumList 4"
 
   , mkTest
       validateCardNumber
       4012888888881881
       True
+      10
       "validateCardNumber 1"
   , mkTest
       validateCardNumber
       4012888888881882
       False
+      10
       "validateCardNumber 2"
   ]
   where
-    mkTest :: (Show b, Eq b) => (a -> b) -> a -> b -> String -> TestTree
-    mkTest = mkTest' sc
+    mkTest :: (Show b, Eq b) => (a -> b) -> a -> b -> Double -> String -> TestTree
+    mkTest = scoreTest' sc


### PR DESCRIPTION
It's annoyed me for a while that the point totals for the local grading code for this assignment don't match the autograder behavior, so I tried fixing it by making the local grading code more similar to [what the 00-lambda assignment does](https://github.com/UCSC-CSE-114A/00-lambda/blob/main/Main.hs).  It's not *exactly* the same as 00-lambda, though, because some of the point totals for this assignment are not whole numbers (😧), so I used `Double` instead of `Int`.